### PR TITLE
Fix errors

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   #require "payjp"
   before_action :set_item, only: [:show, :buy, :purchase, :edit, :update, :destroy]
-  before_action :move_to_index, only: [:edit, :update]
+  before_action :not_edit, only: [:edit, :update]
 
   def index
     @items = Item.includes(:images).order('created_at DESC')
@@ -100,7 +100,7 @@ class ItemsController < ApplicationController
     params.require(:item).permit(:name, :price, :detail, :condition, :category_id, :category, :brand, :size_id, images_attributes: [:src, :_destroy, :id], shipping_attributes: [:fee_burden, :method, :prefecture_from, :period_before_shipping, :id]).merge(user_id: current_user.id)
   end
 
-  def move_to_index
+  def not_edit
     unless user_signed_in? && current_user.id == @item.user_id
       redirect_to action: :index
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   #require "payjp"
-
   before_action :set_item, only: [:show, :buy, :purchase, :edit, :update, :destroy]
+  before_action :move_to_index, only: [:edit]
 
   def index
     @items = Item.includes(:images).order('created_at DESC')
@@ -63,7 +63,7 @@ class ItemsController < ApplicationController
 
   def destroy
     if current_user.id == @item.user_id && @item.destroy
-      redirect_to root_path
+      redirect_to root_path, notice: "出品が削除されました"
     else
       redirect_to item_path(@item.id)
     end
@@ -99,5 +99,10 @@ class ItemsController < ApplicationController
   def item_params
     params.require(:item).permit(:name, :price, :detail, :condition, :category_id, :category, :brand, :size_id, images_attributes: [:src, :_destroy, :id], shipping_attributes: [:fee_burden, :method, :prefecture_from, :period_before_shipping, :id]).merge(user_id: current_user.id)
   end
-  
+
+  def move_to_index
+    unless user_signed_in? && current_user.id == @item.user_id
+      redirect_to action: :index
+    end
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   #require "payjp"
   before_action :set_item, only: [:show, :buy, :purchase, :edit, :update, :destroy]
-  before_action :move_to_index, only: [:edit]
+  before_action :move_to_index, only: [:edit, :update]
 
   def index
     @items = Item.includes(:images).order('created_at DESC')
@@ -45,7 +45,7 @@ class ItemsController < ApplicationController
       if @item.save
         redirect_to root_path
       else
-        redirect_to new_item_path
+        redirect_to new_item_path, alert: "出品に失敗しました"
       end
   end
 
@@ -56,10 +56,10 @@ class ItemsController < ApplicationController
     if @item.update(item_params)
       redirect_to item_path(item_params), notice: "編集が完了しました"
     else
-      flash.now[:alert] = '更新できませんでした'
-      render :edit
+      redirect_to edit_item_path(item_params), alert: "編集に失敗しました"
     end
   end
+  
 
   def destroy
     if current_user.id == @item.user_id && @item.destroy

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,6 @@
 class Item < ApplicationRecord
   validates :name, :price, :detail, :condition, :category_id, :size_id, presence: true
+  validates :images, length: { minimum: 1, maximum: 5}
 
   belongs_to :user, foreign_key: 'user_id'
   has_many :images, dependent: :destroy

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -19,8 +19,6 @@
                     .upper-box
                       = image_tag image.src.url, width: "112", height: "112", alt: "preview"
                     .lower-box
-                      .update-box
-                        %label.edit-btn 編集
                       .delete-box
                         .delete-btn
                           %span 削除

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,4 +12,7 @@
     - if flash[:notice]
       .flash
         = flash[:notice]
+    - if flash[:alert]
+      .flash
+        = flash[:alert]
     = yield


### PR DESCRIPTION
# What
出品者じゃないユーザー及びログインしていないユーザーが商品編集ページのURLにアクセスしてもトップページにリダイうレクトされるようにした。
画像投稿時に0枚もしくは６枚以上だと出品できないようにした。
編集時のエラーハンドリング。
# Why
セキュリティの強化
編集に失敗した事をユーザーに知らせる